### PR TITLE
cli_commands added to service and to test

### DIFF
--- a/service/__init__.py
+++ b/service/__init__.py
@@ -17,7 +17,7 @@ app.config.from_object(config)
 # pylint: disable=wrong-import-position, wrong-import-order
 from service import routes         # noqa: E402, E261
 # pylint: disable=wrong-import-position
-from .common import error_handlers  # noqa: F401 E402
+from .common import error_handlers, cli_commands  # noqa: F401 E402
 
 # Set up logging for production
 log_handlers.init_logging(app, "gunicorn.error")

--- a/service/common/cli_commands.py
+++ b/service/common/cli_commands.py
@@ -1,0 +1,20 @@
+"""
+Flask CLI Command Extensions
+"""
+from service import app
+from service.models import db
+
+
+######################################################################
+# Command to force tables to be rebuilt
+# Usage: flask create-db
+######################################################################
+@app.cli.command("create-db")
+def create_db():
+    """
+    Recreates a local database. You probably should not use this on
+    production.
+    """
+    db.drop_all()
+    db.create_all()
+    db.session.commit()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,21 @@
+"""
+Flask CLI Extensions
+"""
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+from service.common.cli_commands import create_db
+
+
+class TestFlaskCLI(TestCase):
+    """Test Flask CLI Commands"""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch("service.common.cli_commands.db")
+    def test_create_db(self, db_mock):
+        """It should call the create-db command"""
+        db_mock.return_value = MagicMock()
+        result = self.runner.invoke(create_db)
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
cli_commands.py added under the service/common directory
test_cli_commands.py added to tests directory
service/__init__.py modified at line 20 to import cli_commands after error-handlers